### PR TITLE
feat: asyncReplaceError

### DIFF
--- a/Sources/MightyCombine/Extensions/Combine/Publisher+.swift
+++ b/Sources/MightyCombine/Extensions/Combine/Publisher+.swift
@@ -58,6 +58,29 @@ public extension Publisher {
         }
     }
     
+    func asyncReplaceError(with replaceValue: Output) async -> Output? {
+        await withCheckedContinuation { continuation in
+            var cancellable: AnyCancellable?
+            var finishedWithoutValue = true
+            cancellable = first()
+                .sink(receiveCompletion: { compltion in
+                    switch compltion {
+                    case .finished:
+                        if finishedWithoutValue {
+                            continuation.resume(returning: replaceValue)
+                        }
+                    case .failure(_):
+                        continuation.resume(returning: replaceValue)
+                    }
+                    cancellable?.cancel()
+                }, receiveValue: { value in
+                    finishedWithoutValue = false
+                    continuation.resume(returning: value)
+                })
+        }
+    }
+        
+    
     @available(macOS 10.15, *)
     func asyncMap<T>(_ transform: @escaping (Output) async -> T) -> Publishers.FlatMap<Future<T, Failure>, Self> {
         flatMap { value in

--- a/Tests/MightyCombineTests/Extensions/Combine/AsyncReplaceErrorTest.swift
+++ b/Tests/MightyCombineTests/Extensions/Combine/AsyncReplaceErrorTest.swift
@@ -1,0 +1,35 @@
+//
+//  AsyncReplaceErrorTest.swift
+//  
+//
+//  Created by 김인섭 on 10/17/23.
+//
+
+import XCTest
+import Combine
+@testable import MightyCombine
+@testable import TestSource
+
+final class AsyncReplaceErrorTest: XCTestCase {
+
+    func test_Just_same() {
+        Task {
+            let result = await Just(1)
+                .receive(on: DispatchQueue.main)
+                .setFailureType(to: Error.self)
+                .asyncReplaceError(with: 10)
+            
+            XCTAssertEqual(result, 1)
+        }
+    }
+    
+    func test_Fail_replace() {
+        Task {
+            let result = await Fail(error: TestError.testError)
+                .receive(on: DispatchQueue.main)
+                .asyncReplaceError(with: 10)
+            
+            XCTAssertEqual(result, 10)
+        }
+    }
+}


### PR DESCRIPTION
## Example

```swift
func test_Just_same() {
    Task {
        let result = await Just(1)
            .receive(on: DispatchQueue.main)
            .setFailureType(to: Error.self)
            .asyncReplaceError(with: 10)
        
        XCTAssertEqual(result, 1)
    }
}

func test_Fail_replace() {
    Task {
        let result = await Fail(error: TestError.testError)
            .receive(on: DispatchQueue.main)
            .asyncReplaceError(with: 10)
        
        XCTAssertEqual(result, 10)
    }
}
```