### PR TITLE
hotfix: fix null exception

### DIFF
--- a/Sources/MightyCombine/Network/URLSessionable.swift
+++ b/Sources/MightyCombine/Network/URLSessionable.swift
@@ -140,9 +140,12 @@ public enum LogStyle {
 fileprivate extension Data {
     
     func asPrettyJsonString() -> String? {
-        let object = try? JSONSerialization.jsonObject(with: self)
+        guard let object = try? JSONSerialization.jsonObject(with: self) else {
+            return .none
+        }
+        
         let prettyJsonData = try? JSONSerialization.data(
-            withJSONObject: object as Any,
+            withJSONObject: object,
             options: [.prettyPrinted])
         guard let prettyJsonData else { return .none }
         return String(data: prettyJsonData, encoding: .utf8)


### PR DESCRIPTION
```Swift
fileprivate extension Data {

    func asPrettyJsonString() -> String? {
        let object = try? JSONSerialization.jsonObject(with: self)
        let prettyJsonData = try? JSONSerialization.data(
            withJSONObject: object as Any, // 💣 object 가 nil이면 jsonSerilazation 크래시 발생
            options: [.prettyPrinted])
        guard let prettyJsonData else { return .none }
        return String(data: prettyJsonData, encoding: .utf8)
    }
```